### PR TITLE
chore: remove 16.x nodejs workflow

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.x', '18.x', '20.x']
+        node-version: ['18.x', '20.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
remove node16 workflow